### PR TITLE
Upgrades dependencies to laravel 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
+  - 7.2
 
 cache:
   directories:
@@ -11,8 +10,7 @@ cache:
 # Using Testbench you can test for different Laravel versions.
 # The settings below test on each PHP version Laravel 5.4 and 5.5.
 env:
- - TESTBENCH_VERSION=3.4.*
- - TESTBENCH_VERSION=3.5.*
+ - TESTBENCH_VERSION=4.*
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.2
+  - 7.3
 
 cache:
   directories:
@@ -10,7 +11,8 @@ cache:
 # Using Testbench you can test for different Laravel versions.
 # The settings below test on each PHP version Laravel 5.4 and 5.5.
 env:
- - TESTBENCH_VERSION=4.*
+  - TESTBENCH_VERSION=3.*
+  - TESTBENCH_VERSION=4.*
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     "homepage": "https://github.com/:lc:vendor/:lc:package",
     "keywords": ["Laravel", ":uc:package"],
     "require": {
-        "illuminate/support": "~6"
+        "illuminate/support": "~5|~6"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "~3|~4",
         "sempro/phpunit-pretty-print": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     "homepage": "https://github.com/:lc:vendor/:lc:package",
     "keywords": ["Laravel", ":uc:package"],
     "require": {
-        "illuminate/support": "~5"
+        "illuminate/support": "~6"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "~3.0",
+        "orchestra/testbench": "^4.0",
         "sempro/phpunit-pretty-print": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Hi, I am not sure how would you go when supporting laravel 6. I can help if you have a better solution.

For now, it will drop support for laravel 5.x and set defaults to support laravel 6. Let me know what you think or how will you go about this.