### PR TITLE
Update ExampleTest.php

### DIFF
--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
 {
-    public function true_is_true()
+    public function testTrueIsTrue()
     {
         $this->assertTrue(true);
     }

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
 {
-    public function testTrueIsTrue()
+    public function test_true_is_true()
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
Test methods must starts with "test" string, recent PHPUnit (8.5) was showing a warning:
```sh
No tests found in class "Vendor\Package\Tests\ExampleTest".
```