### PR TITLE
Add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/support": "~5|~6|~7|~8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "~8.0|~9.0",
         "mockery/mockery": "^1.1",
         "orchestra/testbench": "~3|~4",
         "sempro/phpunit-pretty-print": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "phpunit/phpunit": "~8.0|~9.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "~3|~4",
+        "orchestra/testbench": "~3|~4|~5|~6",
         "sempro/phpunit-pretty-print": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/:lc:vendor/:lc:package",
     "keywords": ["Laravel", ":uc:package"],
     "require": {
-        "illuminate/support": "~5|~6|~7"
+        "illuminate/support": "~5|~6|~7|~8"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
This PR adds support for Laravel 8, PHPUnit version 9, and allows Orchestra Testbench versions 5 and 6 which support Laravel versions 7 and 8 respectively.