### PR TITLE
Change orchestra/testbench ~7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~9.0",
-        "orchestra/testbench": "~9"
+        "orchestra/testbench": "~7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
There's [no version `~9`](https://packages.tools/testbench/getting-started/introduction.html#version-compatibility) of [`orchestral/testbench`](https://github.com/orchestral/testbench)